### PR TITLE
Implement Pause/Resume shortcut key (P)

### DIFF
--- a/src/scenes/Battle.js
+++ b/src/scenes/Battle.js
@@ -141,6 +141,8 @@ export class Battle extends Scene {
   }
 
   subscribeToEvents() {
+    this.input.keyboard.on('keyup-P', this.onPauseRequested, this);
+
     gameLogicEventEmitter.on(
       GameLogicEvent.PLAYER_FIRE,
       this.onPlayerFire,
@@ -205,7 +207,13 @@ export class Battle extends Scene {
     this.events.once('shutdown', this.unsubscribeFromEvents, this);
   }
 
+  onPauseRequested() {
+    this.scene.launch(SceneKey.PAUSE_MENU);
+  }
+
   unsubscribeFromEvents() {
+    this.input.keyboard.off('keyup-P', this.onPauseRequested, this);
+
     gameLogicEventEmitter.off(
       GameLogicEvent.PLAYER_FIRE,
       this.onPlayerFire,

--- a/src/scenes/Battle.js
+++ b/src/scenes/Battle.js
@@ -289,10 +289,12 @@ export class Battle extends Scene {
   }
 
   onResumeGame() {
+    this.scene.resume(SceneKey.HUD);
     this.scene.resume(this);
   }
 
   onPauseGame() {
+    this.scene.pause(SceneKey.HUD);
     this.scene.pause(this);
   }
 

--- a/src/scenes/HUD.js
+++ b/src/scenes/HUD.js
@@ -131,8 +131,7 @@ export class HUD extends Scene {
   }
 
   onPause() {
-    crossSceneEventEmitter.emit(CrossSceneEvent.PAUSE_GAME);
-    this.scene.launch('PauseMenu');
+    this.scene.launch(SceneKey.PAUSE_MENU);
   }
 
   unsubscribeFromEvents() {

--- a/src/scenes/PauseMenu.js
+++ b/src/scenes/PauseMenu.js
@@ -61,9 +61,14 @@ export class PauseMenu extends Scene {
       ],
       'pause',
     );
+
+    this.input.keyboard.once('keyup-' + 'P', () => {
+      this.resumeGame();
+    });
   }
 
   resumeGame() {
+    this._menuSystem.shutDownCurrentMenu();
     crossSceneEventEmitter.emit(CrossSceneEvent.RESUME_GAME);
     this.scene.stop(this);
   }

--- a/src/scenes/PauseMenu.js
+++ b/src/scenes/PauseMenu.js
@@ -1,11 +1,4 @@
 import { Scene } from 'phaser';
-import {
-  COLORS,
-  WEBSITE_URL,
-  MENU_ITEM_CONFIG,
-  HOVER_TWEEN_CONFIG,
-} from '../constants/menu.js';
-
 import { crossSceneEventEmitter } from '../utils/events.js';
 import { CrossSceneEvent } from '../constants/events.js';
 import { MenuSystem } from '../systems/menuSystem.js';
@@ -19,6 +12,7 @@ export class PauseMenu extends Scene {
   }
 
   create() {
+    crossSceneEventEmitter.emit(CrossSceneEvent.PAUSE_GAME);
     this._menuSystem = new MenuSystem(this);
     this._menuSystem.start(
       [
@@ -62,7 +56,7 @@ export class PauseMenu extends Scene {
       'pause',
     );
 
-    this.input.keyboard.once('keyup-' + 'P', () => {
+    this.input.keyboard.once('keyup-P', () => {
       this.resumeGame();
     });
   }

--- a/src/scenes/PauseMenu.js
+++ b/src/scenes/PauseMenu.js
@@ -13,6 +13,7 @@ export class PauseMenu extends Scene {
 
   create() {
     crossSceneEventEmitter.emit(CrossSceneEvent.PAUSE_GAME);
+    this.cameras.main.setBackgroundColor(0xaa000000);
     this._menuSystem = new MenuSystem(this);
     this._menuSystem.start(
       [


### PR DESCRIPTION
This pull request introduces a pause functionality to the game by adding a new event listener for the 'P' key and updating the relevant scenes to handle game pausing and resuming. The most important changes include adding the `onPauseRequested` method, updating the `PauseMenu` scene, and modifying the `HUD` scene.

### Pause Functionality:

* [`src/scenes/Battle.js`](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74R144-R145): Added `onPauseRequested` method to handle the 'P' key press, launching the `PauseMenu` scene and pausing the HUD. Also added event listeners and handlers for pausing and resuming the game. [[1]](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74R144-R145) [[2]](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74R210-R216) [[3]](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74R292-R297)

* [`src/scenes/HUD.js`](diffhunk://#diff-43174b69126ec49a879604581d3cb5c0b4ed7789900497947414f645eb7bbdedL134-R134): Updated the `onPause` method to launch the `PauseMenu` scene using `SceneKey.PAUSE_MENU` instead of emitting a cross-scene event.

* [`src/scenes/PauseMenu.js`](diffhunk://#diff-654b6160f3ddeacc40085c36a9b0f2269009ffed8a15c657d8784eb2d13acbd9L2-L8): Simplified imports and added functionality to emit a pause event, set a background color, and listen for the 'P' key press to resume the game. [[1]](diffhunk://#diff-654b6160f3ddeacc40085c36a9b0f2269009ffed8a15c657d8784eb2d13acbd9L2-L8) [[2]](diffhunk://#diff-654b6160f3ddeacc40085c36a9b0f2269009ffed8a15c657d8784eb2d13acbd9R15-R16) [[3]](diffhunk://#diff-654b6160f3ddeacc40085c36a9b0f2269009ffed8a15c657d8784eb2d13acbd9R59-R66)