### PR TITLE
Implement Local High Score System

### DIFF
--- a/src/constants/data.js
+++ b/src/constants/data.js
@@ -1,1 +1,8 @@
-export const TOUCH_CONTROLS_KEY = 'enableTouchControls';
+export const RegistryKey = {
+  TOUCH_CONTROLS: 'enable-touch-controls',
+  HIGH_SCORE: 'high-score',
+};
+
+export const LocalStorageKey = {
+  HIGH_SCORE: 'high-score',
+};

--- a/src/constants/events.js
+++ b/src/constants/events.js
@@ -6,6 +6,7 @@ export const CrossSceneEvent = {
   RESUME_GAME: 'resume-game',
   QUIT_GAME: 'quit-game',
   HUD_DESTROYED: 'hud-destroyed',
+  SCORE_RESET: 'score-reset',
 };
 
 export const GameLogicEvent = {

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import { Credits } from './scenes/Credits.js';
 import { PauseMenu } from './scenes/PauseMenu.js';
 import { HUD } from './scenes/HUD.js';
 import { AUTO, Scale, Game } from 'phaser';
-import { TOUCH_CONTROLS_KEY } from './constants/data.js';
+import { RegistryKey } from './constants/data.js';
 import { VirtualJoyStickPlugin } from 'virtualjoystick';
 
 //  Find out more information about the Game Config at:
@@ -46,21 +46,21 @@ const game = new Game(config);
 document.body.addEventListener('pointerdown', onPointerDown);
 
 function onPointerDown(event) {
-  const currentValue = game.registry.get(TOUCH_CONTROLS_KEY);
+  const currentValue = game.registry.get(RegistryKey.TOUCH_CONTROLS);
   const pointerType = event.pointerType;
   if (!currentValue && pointerType === 'touch') {
-    game.registry.set(TOUCH_CONTROLS_KEY, true);
+    game.registry.set(RegistryKey.TOUCH_CONTROLS, true);
     document.addEventListener('keydown', onKeyDown);
   } else if (currentValue && pointerType !== 'touch') {
-    game.registry.set(TOUCH_CONTROLS_KEY, false);
+    game.registry.set(RegistryKey.TOUCH_CONTROLS, false);
   }
 }
 
 function onKeyDown(event) {
-  const currentValue = game.registry.get(TOUCH_CONTROLS_KEY);
+  const currentValue = game.registry.get(RegistryKey.TOUCH_CONTROLS);
   if (currentValue) {
     document.removeEventListener('keydown', onKeyDown);
-    game.registry.set(TOUCH_CONTROLS_KEY, false);
+    game.registry.set(RegistryKey.TOUCH_CONTROLS, false);
   }
 }
 

--- a/src/scenes/Battle.js
+++ b/src/scenes/Battle.js
@@ -23,7 +23,7 @@ import { ScoreUpdateType } from '../constants/score.js';
 import { Player } from '../gameObjects/Player.js';
 import { PLAYER_STARTING_POSITION } from '../constants/spawn.js';
 import { STARTING_LIVES } from '../constants/status.js';
-import { RegistryKey } from '../constants/data.js';
+import { LocalStorageKey, RegistryKey } from '../constants/data.js';
 import { TouchControlsSystem } from '../systems/touchControlsSystem.js';
 import { SceneKey } from '../constants/scene.js';
 
@@ -366,8 +366,14 @@ export class Battle extends Scene {
   }
 
   onGameOver() {
+    this.updateHighScore();
     this._spawnSystem.deactivateEnemySpawnTimer();
     this.reset();
+  }
+  updateHighScore() {
+    const score = this._scoreSystem.getScore();
+    this.game.registry.set(RegistryKey.HIGH_SCORE, score);
+    localStorage.setItem(LocalStorageKey.HIGH_SCORE, score);
   }
 
   update() {

--- a/src/scenes/Battle.js
+++ b/src/scenes/Battle.js
@@ -23,7 +23,7 @@ import { ScoreUpdateType } from '../constants/score.js';
 import { Player } from '../gameObjects/Player.js';
 import { PLAYER_STARTING_POSITION } from '../constants/spawn.js';
 import { STARTING_LIVES } from '../constants/status.js';
-import { TOUCH_CONTROLS_KEY } from '../constants/data.js';
+import { RegistryKey } from '../constants/data.js';
 import { TouchControlsSystem } from '../systems/touchControlsSystem.js';
 import { SceneKey } from '../constants/scene.js';
 
@@ -59,7 +59,9 @@ export class Battle extends Scene {
       enable: false,
     });
 
-    const isTouchControlsEnabled = this.registry.get(TOUCH_CONTROLS_KEY);
+    const isTouchControlsEnabled = this.registry.get(
+      RegistryKey.TOUCH_CONTROLS,
+    );
     const fireButton = this.add
       .circle(490, 270, 50)
       .setStrokeStyle(2, 0xffffff);
@@ -300,7 +302,7 @@ export class Battle extends Scene {
 
   onDataChanged(_parent, key, value) {
     switch (key) {
-      case TOUCH_CONTROLS_KEY:
+      case RegistryKey.TOUCH_CONTROLS:
         if (value) {
           this._movementSystem.activateJoystickMovement();
         } else {

--- a/src/scenes/Battle.js
+++ b/src/scenes/Battle.js
@@ -175,6 +175,7 @@ export class Battle extends Scene {
       this.onLivesUpdated,
       this,
     );
+
     gameLogicEventEmitter.on(GameLogicEvent.GAME_OVER, this.onGameOver, this);
 
     crossSceneEventEmitter.on(
@@ -370,10 +371,15 @@ export class Battle extends Scene {
     this._spawnSystem.deactivateEnemySpawnTimer();
     this.reset();
   }
+
   updateHighScore() {
+    const storedHighScore = this.game.registry.get(RegistryKey.HIGH_SCORE);
     const score = this._scoreSystem.getScore();
-    this.game.registry.set(RegistryKey.HIGH_SCORE, score);
-    localStorage.setItem(LocalStorageKey.HIGH_SCORE, score);
+
+    if (score > storedHighScore) {
+      this.game.registry.set(RegistryKey.HIGH_SCORE, score);
+      localStorage.setItem(LocalStorageKey.HIGH_SCORE, score);
+    }
   }
 
   update() {
@@ -389,6 +395,8 @@ export class Battle extends Scene {
       this._statusSystem.reset();
       this._scoreSystem.reset();
       this._spawnSystem.reset();
+
+      crossSceneEventEmitter.emit(CrossSceneEvent.SCORE_RESET);
     });
   }
 

--- a/src/scenes/Boot.js
+++ b/src/scenes/Boot.js
@@ -1,5 +1,6 @@
 import { Scene } from 'phaser';
 import { SceneKey } from '../constants/scene.js';
+import { LocalStorageKey, RegistryKey } from '../constants/data.js';
 
 export class Boot extends Scene {
   constructor() {
@@ -12,6 +13,14 @@ export class Boot extends Scene {
   }
 
   create() {
+    const storedHighScore = window.localStorage.getItem(
+      LocalStorageKey.HIGH_SCORE,
+    );
+    this.game.registry.set(RegistryKey.HIGH_SCORE, storedHighScore ?? 0);
+    console.log(
+      'Stored High score:',
+      this.game.registry.get(RegistryKey.HIGH_SCORE),
+    );
     this.scene.start(SceneKey.PRELOADER);
   }
 }

--- a/src/scenes/Boot.js
+++ b/src/scenes/Boot.js
@@ -16,11 +16,8 @@ export class Boot extends Scene {
     const storedHighScore = window.localStorage.getItem(
       LocalStorageKey.HIGH_SCORE,
     );
+
     this.game.registry.set(RegistryKey.HIGH_SCORE, storedHighScore ?? 0);
-    console.log(
-      'Stored High score:',
-      this.game.registry.get(RegistryKey.HIGH_SCORE),
-    );
     this.scene.start(SceneKey.PRELOADER);
   }
 }

--- a/src/scenes/HUD.js
+++ b/src/scenes/HUD.js
@@ -127,7 +127,17 @@ export class HUD extends Scene {
       this,
     );
 
+    crossSceneEventEmitter.on(
+      CrossSceneEvent.SCORE_RESET,
+      this.onScoreReset,
+      this,
+    );
+
     this.events.once('shutdown', this.unsubscribeFromEvents, this);
+  }
+
+  onScoreReset() {
+    this._highScoreLabelText.setVisible(false);
   }
 
   onScreenShakeRequest(screenShakeType) {

--- a/src/scenes/HUD.js
+++ b/src/scenes/HUD.js
@@ -17,6 +17,7 @@ export class HUD extends Scene {
   _healthIcon;
   _healthBar;
   _vfxSystem;
+  _highScoreLabelText;
 
   constructor() {
     super(SceneKey.HUD);
@@ -75,11 +76,24 @@ export class HUD extends Scene {
     this._scoreValueText = this.add
       .text(
         this.cameras.main.width - HUD_PADDING.horizontalPadding,
-        scoreLabel.y + scoreLabel.height / 2 + 8,
+        scoreLabel.y + scoreLabel.height,
         '0',
         {
           fontFamily: 'usuzi',
           fontSize: 24,
+          color: '#ffffff',
+        },
+      )
+      .setOrigin(1, 0);
+
+    this._highScoreLabelText = this.add
+      .text(
+        this.cameras.main.width - HUD_PADDING.horizontalPadding,
+        this._scoreValueText.y + this._scoreValueText.height,
+        'BEST',
+        {
+          fontFamily: 'usuzi',
+          fontSize: 12,
           color: '#ffffff',
         },
       )

--- a/src/scenes/HUD.js
+++ b/src/scenes/HUD.js
@@ -10,6 +10,7 @@ import { HealthBar } from '../UI/HealthBar.js';
 import { VFXSystem } from '../systems/vfxSystem.js';
 import { SceneKey } from '../constants/scene.js';
 import { MENU_ITEM_CONFIG } from '../constants/menu.js';
+import { RegistryKey } from '../constants/data.js';
 
 export class HUD extends Scene {
   _scoreValueText;
@@ -97,6 +98,7 @@ export class HUD extends Scene {
           color: '#ffffff',
         },
       )
+      .setVisible(false)
       .setOrigin(1, 0);
 
     this._vfxSystem = new VFXSystem(this);
@@ -138,6 +140,14 @@ export class HUD extends Scene {
 
   onUpdateScore(nextPointsValue) {
     this._scoreValueText.text = String(nextPointsValue);
+    if (this._highScoreLabelText.visible) {
+      return;
+    }
+
+    const storedHighScore = this.game.registry.get(RegistryKey.HIGH_SCORE);
+    if (nextPointsValue > storedHighScore) {
+      this._highScoreLabelText.setVisible(true);
+    }
   }
 
   onUpdateLives(nextLivesValue) {

--- a/src/systems/combatSystem.js
+++ b/src/systems/combatSystem.js
@@ -63,8 +63,8 @@ export class CombatSystem {
         );
 
         this.destroyShip(player);
-        gameLogicEventEmitter.emit(GameLogicEvent.PLAYER_DEATH);
         gameLogicEventEmitter.emit(GameLogicEvent.ENEMY_DEATH);
+        gameLogicEventEmitter.emit(GameLogicEvent.PLAYER_DEATH);
       },
     );
 


### PR DESCRIPTION
This pull request includes several changes to refactor constants, add new game events, and update the high score functionality. The most important changes include the creation of new constant objects, the addition of a score reset event, and the implementation of high score updates and display.

### Refactoring constants:
* [`src/constants/data.js`](diffhunk://#diff-f232d6d703356219391ecd0c4be0ca3188eb3a4818f11a5a8c149cab4ff209d9L1-R8): Replaced individual constant exports with `RegistryKey` and `LocalStorageKey` objects for better organization.
* Updated imports and references to use the new `RegistryKey` and `LocalStorageKey` objects across multiple files (`src/main.js`, `src/scenes/Battle.js`, `src/scenes/Boot.js`, `src/scenes/HUD.js`). [[1]](diffhunk://#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79L9-R9) [[2]](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74L26-R26) [[3]](diffhunk://#diff-616ca1693c2901b4c3b49e944450b8af62663740dec1d5b0579d48c7f4282739R3) [[4]](diffhunk://#diff-43174b69126ec49a879604581d3cb5c0b4ed7789900497947414f645eb7bbdedR13-R21)

### New game events:
* [`src/constants/events.js`](diffhunk://#diff-14c8a58754aa579483f8081cee34ba99c9bcbcfd0266d44155d7502d403f7ab2R9): Added a new `SCORE_RESET` event to `CrossSceneEvent`.
* [`src/scenes/HUD.js`](diffhunk://#diff-43174b69126ec49a879604581d3cb5c0b4ed7789900497947414f645eb7bbdedR130-R142): Implemented handling of the `SCORE_RESET` event to reset the high score label visibility.

### High score functionality:
* [`src/scenes/Battle.js`](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74R370-R384): Added methods to update the high score in both the game registry and local storage. [[1]](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74R370-R384) [[2]](diffhunk://#diff-3cfd38a38665241526ae036f476c28f183179f71530383fb49baa7d1e59c5b74R398-R399)
* [`src/scenes/Boot.js`](diffhunk://#diff-616ca1693c2901b4c3b49e944450b8af62663740dec1d5b0579d48c7f4282739R16-R20): Initialized the high score from local storage when the game boots.
* [`src/scenes/HUD.js`](diffhunk://#diff-43174b69126ec49a879604581d3cb5c0b4ed7789900497947414f645eb7bbdedR90-R103): Displayed the high score label when the current score exceeds the stored high score. [[1]](diffhunk://#diff-43174b69126ec49a879604581d3cb5c0b4ed7789900497947414f645eb7bbdedR90-R103) [[2]](diffhunk://#diff-43174b69126ec49a879604581d3cb5c0b4ed7789900497947414f645eb7bbdedR153-R160)