### PR TITLE
83 menu UI buttons should be a part of the game over scene timeline animation

### DIFF
--- a/src/scenes/GameOver.js
+++ b/src/scenes/GameOver.js
@@ -12,7 +12,7 @@ import { ScreenShakeType } from '../constants/vfx.js';
 
 const MenuItemNames = {
   PLAY_AGAIN: 'play-again',
-  MAIN_MENU: 'main-menu'
+  MAIN_MENU: 'main-menu',
 };
 
 export class GameOver extends Scene {
@@ -84,10 +84,10 @@ export class GameOver extends Scene {
 
     this._menuItems = [
       this._menuSystem.getMenuItem(MenuItemNames.PLAY_AGAIN),
-      this._menuSystem.getMenuItem(MenuItemNames.MAIN_MENU)
-    ].filter(item => !!item);
+      this._menuSystem.getMenuItem(MenuItemNames.MAIN_MENU),
+    ].filter((item) => !!item);
 
-    this._hideMenuItems(); 
+    this._hideMenuItems();
 
     const timeline = this.add.timeline([
       {
@@ -126,23 +126,24 @@ export class GameOver extends Scene {
               this.revealStat('highScore');
             },
           },
-      isNewHighScore ?
-          {
+      isNewHighScore
+        ? {
             at: 3750,
             run: () => {
               this.showMenuItems();
-            }
+            },
           }
         : {
-          at: 3000,
-          run: () => {
-            this.showMenuItems();
-          }
-        }
-
+            at: 3000,
+            run: () => {
+              this.showMenuItems();
+            },
+          },
     ]);
 
     timeline.play();
+
+    this.input.once('pointerup', () => (timeline.timeScale = 10.0));
   }
 
   revealStat(key, options) {

--- a/src/scenes/GameOver.js
+++ b/src/scenes/GameOver.js
@@ -10,6 +10,11 @@ import { DependencyKey } from '../constants/injector.js';
 import { SoundFXKey } from '../constants/audio.js';
 import { ScreenShakeType } from '../constants/vfx.js';
 
+const MenuItemNames = {
+  PLAY_AGAIN: 'play-again',
+  MAIN_MENU: 'main-menu'
+};
+
 export class GameOver extends Scene {
   injector;
   _audioSystem;
@@ -20,6 +25,7 @@ export class GameOver extends Scene {
   _vfxSystem;
   _statsContainer;
   _newHighScoreBlinkTimer;
+  _menuItems;
 
   constructor() {
     super(SceneKey.GAME_OVER);
@@ -61,10 +67,12 @@ export class GameOver extends Scene {
           customContent: this._statsContainer,
           items: [
             {
+              name: MenuItemNames.PLAY_AGAIN,
               label: 'Play Again',
               action: this.resetGame,
             },
             {
+              name: MenuItemNames.MAIN_MENU,
               label: 'Back To Main Menu',
               action: this.quitGame,
             },
@@ -73,6 +81,13 @@ export class GameOver extends Scene {
       ],
       'pause',
     );
+
+    this._menuItems = [
+      this._menuSystem.getMenuItem(MenuItemNames.PLAY_AGAIN),
+      this._menuSystem.getMenuItem(MenuItemNames.MAIN_MENU)
+    ].filter(item => !!item);
+
+    this._hideMenuItems(); 
 
     const timeline = this.add.timeline([
       {
@@ -111,6 +126,20 @@ export class GameOver extends Scene {
               this.revealStat('highScore');
             },
           },
+      isNewHighScore ?
+          {
+            at: 3750,
+            run: () => {
+              this.showMenuItems();
+            }
+          }
+        : {
+          at: 3000,
+          run: () => {
+            this.showMenuItems();
+          }
+        }
+
     ]);
 
     timeline.play();
@@ -224,6 +253,23 @@ export class GameOver extends Scene {
     lastRenderedItem = renderedHighScore[renderedHighScore.length - 1];
 
     return renderedItems;
+  }
+
+  _hideMenuItems() {
+    const count = this._menuItems.length;
+    for (let i = 0; i < count; i++) {
+      const item = this._menuItems[i];
+      item.setActive(false).setVisible(false);
+    }
+  }
+
+  showMenuItems() {
+    const count = this._menuItems.length;
+
+    for (let i = 0; i < count; i++) {
+      const item = this._menuItems[i];
+      item.setActive(true).setVisible(true);
+    }
   }
 
   _renderStatItem(item, options) {

--- a/src/systems/menuSystem.js
+++ b/src/systems/menuSystem.js
@@ -65,6 +65,7 @@ export class MenuSystem {
   /**
    * @param {Array<Menu>} menus
    * @param {string} firstMenuKey
+   * @return {GameObjects.Container}
    */
   start(menus, firstMenuKey) {
     this.firstMenuKey = firstMenuKey;
@@ -90,6 +91,16 @@ export class MenuSystem {
 
     this._currentFooterContainer.add(this._renderFooter(this._currentMenu));
     realignFooter(this.scene, this._currentFooterContainer);
+    return this._currentMenuContainer;
+  }
+
+  getMenuItem(name) {
+    const item = this._currentMenuContainer.getByName(name);
+    if (!item) {
+      return undefined;
+    }
+
+    return item;
   }
 
   updateItemText(name, value) {

--- a/src/systems/menuSystem.js
+++ b/src/systems/menuSystem.js
@@ -65,7 +65,6 @@ export class MenuSystem {
   /**
    * @param {Array<Menu>} menus
    * @param {string} firstMenuKey
-   * @return {GameObjects.Container}
    */
   start(menus, firstMenuKey) {
     this.firstMenuKey = firstMenuKey;
@@ -91,7 +90,6 @@ export class MenuSystem {
 
     this._currentFooterContainer.add(this._renderFooter(this._currentMenu));
     realignFooter(this.scene, this._currentFooterContainer);
-    return this._currentMenuContainer;
   }
 
   getMenuItem(name) {


### PR DESCRIPTION
This pull request introduces enhancements to the `GameOver` scene by adding menu item management capabilities and improving the `MenuSystem` to support retrieving menu items by name. The changes focus on better structuring menu interactions and ensuring a smoother user experience.

### Changes to `GameOver` Scene:

* **Menu Item Constants Added**: Introduced `MenuItemNames` to define constants for menu item names (`PLAY_AGAIN` and `MAIN_MENU`) for better maintainability and readability. (`[src/scenes/GameOver.jsR13-R17](diffhunk://#diff-8358b06e6032a91371e66c1e8f334b5ac7e3cb32d70618cf25f72655b28279d0R13-R17)`)
* **Menu Item Initialization and Management**:
  - Added a `_menuItems` property to the `GameOver` class to store references to menu items. (`[src/scenes/GameOver.jsR28](diffhunk://#diff-8358b06e6032a91371e66c1e8f334b5ac7e3cb32d70618cf25f72655b28279d0R28)`)
  - Populated `_menuItems` using the new `getMenuItem` method from `MenuSystem` and implemented `_hideMenuItems` and `showMenuItems` methods to control their visibility and interactivity. (`[[1]](diffhunk://#diff-8358b06e6032a91371e66c1e8f334b5ac7e3cb32d70618cf25f72655b28279d0R85-R91)`, `[[2]](diffhunk://#diff-8358b06e6032a91371e66c1e8f334b5ac7e3cb32d70618cf25f72655b28279d0R259-R275)`)
* **Dynamic Menu Visibility**: Adjusted the timeline to dynamically reveal menu items based on whether a new high score was achieved. (`[src/scenes/GameOver.jsR129-R146](diffhunk://#diff-8358b06e6032a91371e66c1e8f334b5ac7e3cb32d70618cf25f72655b28279d0R129-R146)`)

### Changes to `MenuSystem`:

* **Menu Item Retrieval**: Added a `getMenuItem` method to retrieve menu items by name, enabling the `GameOver` scene to manage its menu items more effectively. (`[src/systems/menuSystem.jsR95-R103](diffhunk://#diff-41476186789fe165d6ba77031efe16c0fc3c88e5c9eb2431bd8f6a59c028a58aR95-R103)`)

Fixes #83 